### PR TITLE
Integrate CyberIntelGPT style plugin

### DIFF
--- a/scripts/cyberintel_runner.py
+++ b/scripts/cyberintel_runner.py
@@ -1,0 +1,45 @@
+import sys
+import json
+import os
+import re
+from PyPDF2 import PdfReader
+
+
+def extract_text(pdf_path):
+    reader = PdfReader(pdf_path)
+    text = ""
+    for page in reader.pages:
+        if page.extract_text():
+            text += page.extract_text() + "\n"
+    return text
+
+
+def extract_iocs(text):
+    ips = re.findall(r"\b(?:\d{1,3}\.){3}\d{1,3}\b", text)
+    domains = re.findall(r"\b(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}\b", text)
+    urls = re.findall(r"https?://[^\s]+", text)
+    hashes = re.findall(r"\b[A-Fa-f0-9]{32,64}\b", text)
+    return {
+        "ips": sorted(set(ips)),
+        "domains": sorted(set(domains)),
+        "urls": sorted(set(urls)),
+        "hashes": sorted(set(hashes)),
+    }
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python cyberintel_runner.py <pdf_path>")
+        sys.exit(1)
+    pdf_path = sys.argv[1]
+    text = extract_text(pdf_path)
+    iocs = extract_iocs(text)
+    os.makedirs('output', exist_ok=True)
+    with open('output/iocs_output.json', 'w') as f:
+        json.dump(iocs, f, indent=4)
+    print(json.dumps(iocs))
+
+
+if __name__ == '__main__':
+    main()
+

--- a/src/Sigma.Core/Domain/Service/KernelService.cs
+++ b/src/Sigma.Core/Domain/Service/KernelService.cs
@@ -272,6 +272,7 @@ namespace Sigma.Core.Domain.Service
             kernel.ImportPluginFromObject(new ConversationSummaryPlugin(), "ConversationSummaryPlugin");
             //kernel.ImportPluginFromObject(new TimePlugin(), "TimePlugin");
             kernel.ImportPluginFromPromptDirectory(Path.Combine(RepoFiles.SamplePluginsPath(), "KMSPlugin"));
+            kernel.ImportPluginFromPromptDirectory(Path.Combine(RepoFiles.SamplePluginsPath(), "CyberIntelPlugin"));
         }
 
         /// <summary>

--- a/src/Sigma/Sigma.csproj
+++ b/src/Sigma/Sigma.csproj
@@ -18,9 +18,18 @@
   </ItemGroup>
 	
   <ItemGroup>
-  	<None Update="plugins\KMSPlugin\Ask\skprompt.txt">
-  	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-  	</None>
+        <None Update="plugins\KMSPlugin\Ask\skprompt.txt">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="plugins\CyberIntelPlugin\GenerateRules\skprompt.txt">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="plugins\CyberIntelPlugin\GenerateRules\config.json">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="..\..\scripts\cyberintel_runner.py">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
   </ItemGroup>
 	
 </Project>

--- a/src/Sigma/plugins/CyberIntelPlugin/GenerateRules/config.json
+++ b/src/Sigma/plugins/CyberIntelPlugin/GenerateRules/config.json
@@ -1,0 +1,10 @@
+{
+  "schema": 1,
+  "description": "Generate detection rules from extracted IOCs",
+  "execution_settings": {
+    "default": {
+      "temperature": 0.2,
+      "top_p": 0.8
+    }
+  }
+}

--- a/src/Sigma/plugins/CyberIntelPlugin/GenerateRules/skprompt.txt
+++ b/src/Sigma/plugins/CyberIntelPlugin/GenerateRules/skprompt.txt
@@ -1,0 +1,12 @@
+Use the provided Indicators of Compromise to craft concise detection rules for various security platforms.
+
+Input IOCs:
+{{$iocs}}
+
+Generate rules for:
+- Microsoft Sentinel
+- Splunk
+- Network IPS/IDS
+- Firewalls
+
+Return the rules in a readable list grouped by platform.

--- a/src/Sigma/plugins/Functions/CyberIntelFunctions.cs
+++ b/src/Sigma/plugins/Functions/CyberIntelFunctions.cs
@@ -1,0 +1,80 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Sigma.Core.Common;
+
+namespace Sigma.plugins.Functions;
+
+public class CyberIntelFunctions
+{
+    /// <summary>
+    /// Extract IOCs from a CTI PDF report using the CyberIntel runner.
+    /// </summary>
+    /// <param name="pdfPath">Path to the PDF report</param>
+    /// <returns>JSON string of extracted IOCs</returns>
+    [SigmaFunction]
+    public string ExtractIocs(string pdfPath)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "python3",
+            Arguments = $"scripts/cyberintel_runner.py \"{pdfPath}\"",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        using var process = Process.Start(psi)!;
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+        {
+            return $"Error: {error}";
+        }
+        return output.Trim();
+    }
+
+    /// <summary>
+    /// Generate detection rules for Sentinel, Splunk and network devices.
+    /// </summary>
+    /// <param name="iocJson">JSON string produced by ExtractIocs</param>
+    /// <returns>JSON string with rules</returns>
+    [SigmaFunction]
+    public string GenerateRules(string iocJson)
+    {
+        var document = JsonDocument.Parse(iocJson);
+        var rules = new Dictionary<string, List<string>>
+        {
+            ["sentinel"] = new(),
+            ["splunk"] = new(),
+            ["ids_ips"] = new(),
+            ["firewall"] = new()
+        };
+
+        if (document.RootElement.TryGetProperty("ips", out var ips))
+        {
+            foreach (var ip in ips.EnumerateArray().Select(e => e.GetString()))
+            {
+                if (string.IsNullOrWhiteSpace(ip)) continue;
+                rules["sentinel"].Add($"SecurityEvent | where EventData contains '{ip}'");
+                rules["splunk"].Add($"search index=* \"{ip}\"");
+                rules["ids_ips"].Add($"alert ip any any -> {ip} any (msg:'IOC hit';)");
+                rules["firewall"].Add($"block ip {ip}");
+            }
+        }
+
+        if (document.RootElement.TryGetProperty("domains", out var domains))
+        {
+            foreach (var domain in domains.EnumerateArray().Select(e => e.GetString()))
+            {
+                if (string.IsNullOrWhiteSpace(domain)) continue;
+                rules["sentinel"].Add($"SecurityEvent | where EventData contains '{domain}'");
+                rules["splunk"].Add($"search index=* \"{domain}\"");
+                rules["ids_ips"].Add($"alert tcp any any -> any 80 (msg:'IOC domain';content:'{domain}';)");
+                rules["firewall"].Add($"block domain {domain}");
+            }
+        }
+
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        return JsonSerializer.Serialize(rules, options);
+    }
+}


### PR DESCRIPTION
## Summary
- add Python IOC extractor inspired by CyberIntelGPT
- generate Sentinel/Splunk/IPS/firewall rules from IOCs
- register new CyberIntel plugin and include prompts
- copy plugin resources and runner script in the build output

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68892fc46100832481531a7b757b192d