### PR TITLE
Add threat intelligence service

### DIFF
--- a/src/Sigma.Core/Domain/Interface/IThreatIntelService.cs
+++ b/src/Sigma.Core/Domain/Interface/IThreatIntelService.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using Sigma.Core.Repositories;
+
+namespace Sigma.Core.Domain.Interface
+{
+    public interface IThreatIntelService
+    {
+        Task<string> RetrieveThreatDataAsync(string query);
+        Task<string> GenerateReportAsync(Apps app, string threatData);
+    }
+}

--- a/src/Sigma.Core/Domain/Service/ThreatIntelService.cs
+++ b/src/Sigma.Core/Domain/Service/ThreatIntelService.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel;
+using Sigma.Core.Domain.Interface;
+using Sigma.Core.Repositories;
+using Sigma.Core.Utils;
+
+namespace Sigma.Core.Domain.Service
+{
+    public class ThreatIntelService : IThreatIntelService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly IConfiguration _config;
+        private readonly IKernelService _kernelService;
+
+        public ThreatIntelService(HttpClient httpClient, IConfiguration config, IKernelService kernelService)
+        {
+            _httpClient = httpClient;
+            _config = config;
+            _kernelService = kernelService;
+        }
+
+        public async Task<string> RetrieveThreatDataAsync(string query)
+        {
+            var endpoint = _config["ThreatIntel:ExaEndpoint"] ?? "https://api.exa.ai/search";
+            var apiKey = _config["ThreatIntel:ExaApiKey"] ?? Environment.GetEnvironmentVariable("EXA_API_KEY");
+            var url = $"{endpoint}?q={Uri.EscapeDataString(query)}";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            if (!string.IsNullOrEmpty(apiKey))
+            {
+                request.Headers.Add("Authorization", $"Bearer {apiKey}");
+            }
+            var response = await _httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        public async Task<string> GenerateReportAsync(Apps app, string threatData)
+        {
+            var kernel = _kernelService.GetKernelByApp(app);
+            await _kernelService.ImportFunctionsByApp(app, kernel);
+            var promptPath = Path.Combine(RepoFiles.SamplePluginsPath(), "ThreatIntelPlugin", "GenerateReport", "skprompt.txt");
+            var prompt = await File.ReadAllTextAsync(promptPath);
+            var func = kernel.CreateFunctionFromPrompt(prompt);
+            var result = await kernel.InvokeAsync(func, new() { ["data"] = threatData });
+            return result.GetValue<string>();
+        }
+    }
+}

--- a/src/Sigma/Sigma.csproj
+++ b/src/Sigma/Sigma.csproj
@@ -27,6 +27,12 @@
         <None Update="plugins\CyberIntelPlugin\GenerateRules\config.json">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Update="plugins\ThreatIntelPlugin\GenerateReport\skprompt.txt">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="plugins\ThreatIntelPlugin\GenerateReport\config.json">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Update="..\..\scripts\cyberintel_runner.py">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/src/Sigma/plugins/ThreatIntelPlugin/GenerateReport/config.json
+++ b/src/Sigma/plugins/ThreatIntelPlugin/GenerateReport/config.json
@@ -1,0 +1,10 @@
+{
+  "schema": 1,
+  "description": "Generate cyber threat intelligence report from CVE data",
+  "execution_settings": {
+    "default": {
+      "temperature": 0.3,
+      "top_p": 0.8
+    }
+  }
+}

--- a/src/Sigma/plugins/ThreatIntelPlugin/GenerateReport/skprompt.txt
+++ b/src/Sigma/plugins/ThreatIntelPlugin/GenerateReport/skprompt.txt
@@ -1,0 +1,11 @@
+Analyze the following CVE or vulnerability data and produce a concise Cyber Threat Intelligence Report.
+
+Input Data:
+{{$data}}
+
+The report should include:
+- **Threat Summary** describing the overall risk
+- **Vulnerabilities** list
+- **Recommended Mitigations**
+
+Return the report in Markdown format.

--- a/tests/Sigma.Tests/ThreatIntelServiceTests.cs
+++ b/tests/Sigma.Tests/ThreatIntelServiceTests.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Sigma.Core.Domain.Interface;
+using Sigma.Core.Domain.Service;
+using Sigma.Core.Repositories;
+using Xunit;
+
+namespace Sigma.Tests
+{
+    public class ThreatIntelServiceTests
+    {
+        private class TestHandler : HttpMessageHandler
+        {
+            public HttpRequestMessage? LastRequest { get; private set; }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("test")
+                };
+                return Task.FromResult(response);
+            }
+        }
+
+        [Fact]
+        public async Task RetrieveThreatDataAsync_SendsRequest()
+        {
+            var handler = new TestHandler();
+            var client = new HttpClient(handler);
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string,string>
+            {
+                ["ThreatIntel:ExaEndpoint"] = "https://example.com/search",
+                ["ThreatIntel:ExaApiKey"] = "key"
+            }).Build();
+            var kernelService = new Mock<IKernelService>();
+            var service = new ThreatIntelService(client, config, kernelService.Object);
+
+            var result = await service.RetrieveThreatDataAsync("cve-123");
+
+            Assert.Equal("test", result);
+            Assert.NotNull(handler.LastRequest);
+            Assert.Equal("https://example.com/search?q=cve-123", handler.LastRequest!.RequestUri!.ToString());
+            Assert.True(handler.LastRequest!.Headers.Contains("Authorization"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `IThreatIntelService` and `ThreatIntelService`
- add new plugin `ThreatIntelPlugin/GenerateReport`
- copy plugin assets in Sigma project file
- test threat intel service request logic

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68893c1adcb083248c2344a112b9b170