### PR TITLE
Add GAN cyber range plugin

### DIFF
--- a/scripts/gan_range_runner.py
+++ b/scripts/gan_range_runner.py
@@ -1,0 +1,44 @@
+import sys
+import json
+
+# Simulated CLI for the GAN cyber range simulator
+# Usage: python3 gan_range_runner.py <command>
+# Commands: start, metrics, stop
+
+
+def start_simulation():
+    print("Simulation started")
+
+
+def get_metrics():
+    metrics = {
+        "compromise_rate": 0.15,
+        "avg_detection_time": "5m",
+        "patches_deployed": 3
+    }
+    print(json.dumps(metrics))
+
+
+def stop_simulation():
+    print("Simulation stopped")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: gan_range_runner.py <start|metrics|stop>", file=sys.stderr)
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    if cmd == "start":
+        start_simulation()
+    elif cmd == "metrics":
+        get_metrics()
+    elif cmd == "stop":
+        stop_simulation()
+    else:
+        print(f"Unknown command: {cmd}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Sigma/Sigma.csproj
+++ b/src/Sigma/Sigma.csproj
@@ -36,6 +36,9 @@
         <None Update="..\..\scripts\cyberintel_runner.py">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Update="..\..\scripts\gan_range_runner.py">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
   </ItemGroup>
 	
 </Project>

--- a/src/Sigma/plugins/Functions/CyberRangeFunctions.cs
+++ b/src/Sigma/plugins/Functions/CyberRangeFunctions.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics;
+using Sigma.Core.Common;
+
+namespace Sigma.plugins.Functions;
+
+public class CyberRangeFunctions
+{
+    /// <summary>
+    /// Start the GAN cyber range simulation.
+    /// </summary>
+    /// <returns>Output from the simulator</returns>
+    [SigmaFunction]
+    public string StartSimulation()
+    {
+        return RunCommand("start");
+    }
+
+    /// <summary>
+    /// Get metrics from the running simulation.
+    /// </summary>
+    /// <returns>JSON string of metrics</returns>
+    [SigmaFunction]
+    public string GetMetrics()
+    {
+        return RunCommand("metrics");
+    }
+
+    /// <summary>
+    /// Stop the running GAN cyber range simulation.
+    /// </summary>
+    /// <returns>Output from the simulator</returns>
+    [SigmaFunction]
+    public string StopSimulation()
+    {
+        return RunCommand("stop");
+    }
+
+    private static string RunCommand(string command)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "python3",
+            Arguments = $"scripts/gan_range_runner.py {command}",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        using var process = Process.Start(psi)!;
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return process.ExitCode == 0 ? output.Trim() : $"Error: {error}";
+    }
+}


### PR DESCRIPTION
## Summary
- add CyberRangeFunctions to start/metrics/stop GAN simulator
- include gan_range_runner.py script as a simulator stub
- copy new script in Sigma project build output

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68894ea7817c8324ad9dd0d49a277c91