### PR TITLE
Add sample threat intel backend and React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ English | [简体中文](README_zh-CN.md)
 - Support for implementing Function Calling without native API through intent recognition.
 - Support knowledge-based RAG
 - Automated Security Assessment module leveraging reinforcement learning and LLMs
+- Multi-source IOC ingestion from OTX, Shodan, Censys, and VirusTotal
+- FastAPI backend with SQLModel-based storage and REST API
+- React frontend (Next.js + Chakra UI) with live IOC feed and AI summaries
 - Based on an earlier version of AntSK
 
 ## 📦 Installation Guide
@@ -40,6 +43,18 @@ $ dotnet run --project src/sigma
 ```
 
 - Create a account and engjoy!
+### Python backend
+```bash
+$ pip install -r backend/requirements.txt
+$ uvicorn backend.main:app --reload
+```
+
+### React frontend
+```bash
+$ cd frontend
+$ npm install
+$ npm run dev
+```
 
 ## 🔨 Development
 

--- a/backend/ingest.py
+++ b/backend/ingest.py
@@ -1,0 +1,58 @@
+from typing import List
+from datetime import datetime
+import os
+import requests
+from .models import Indicator
+
+OTX_URL = "https://otx.alienvault.com/api/v1/indicators/export"
+SHODAN_URL = "https://api.shodan.io/shodan/host/search"
+CENSYS_URL = "https://search.censys.io/api/v2/hosts/search"
+VT_URL = "https://www.virustotal.com/api/v3/ip_addresses/{ip}"
+
+
+def fetch_otx(limit: int = 10) -> List[Indicator]:
+    api_key = os.getenv("OTX_API_KEY", "")
+    params = {"type": "IPv4", "limit": str(limit)}
+    headers = {"X-OTX-API-KEY": api_key} if api_key else {}
+    resp = requests.get(OTX_URL, params=params, headers=headers, timeout=10)
+    resp.raise_for_status()
+    lines = [l.strip() for l in resp.text.splitlines() if l.strip()]
+    return [Indicator(source="OTX", ioc=l, type="ip", first_seen=datetime.utcnow()) for l in lines]
+
+
+def fetch_shodan(query: str = "malware") -> List[Indicator]:
+    api_key = os.getenv("SHODAN_API_KEY", "")
+    params = {"key": api_key, "query": query}
+    resp = requests.get(SHODAN_URL, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    indicators = []
+    for match in data.get("matches", []):
+        ip = match.get("ip_str")
+        if ip:
+            indicators.append(Indicator(source="Shodan", ioc=ip, type="ip"))
+    return indicators
+
+
+def fetch_censys(query: str = "services.service_name: HTTP") -> List[Indicator]:
+    uid = os.getenv("CENSYS_UID", "")
+    secret = os.getenv("CENSYS_SECRET", "")
+    headers = {"Accept": "application/json"}
+    resp = requests.post(CENSYS_URL, auth=(uid, secret), json={"q": query, "per_page": 10}, headers=headers, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    results = data.get("result", {}).get("hits", [])
+    return [Indicator(source="Censys", ioc=r.get("ip"), type="ip") for r in results if r.get("ip")]
+
+
+def fetch_virustotal(ip: str) -> List[Indicator]:
+    api_key = os.getenv("VT_API_KEY", "")
+    headers = {"x-apikey": api_key}
+    resp = requests.get(VT_URL.format(ip=ip), headers=headers, timeout=10)
+    if resp.status_code != 200:
+        return []
+    data = resp.json()
+    malicious = data.get("data", {}).get("attributes", {}).get("last_analysis_stats", {}).get("malicious", 0)
+    if malicious:
+        return [Indicator(source="VirusTotal", ioc=ip, type="ip")]
+    return []

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -1,0 +1,20 @@
+import os
+from typing import List
+
+import openai
+
+
+async def summarize_iocs(iocs: List[str]) -> str:
+    """Generate a summary using the configured LLM provider."""
+    provider = os.getenv("LLM_PROVIDER", "openai")
+    if provider == "openai":
+        api_key = os.getenv("OPENAI_API_KEY")
+        openai.api_key = api_key
+        prompt = "Summarize the following IOCs for a SOC analyst:\n" + "\n".join(iocs)
+        chat_completion = await openai.ChatCompletion.acreate(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return chat_completion.choices[0].message.content
+    # Placeholder for other providers like claude, gemini, perplexity, ollama
+    return "LLM provider not configured"

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,51 @@
+from fastapi import FastAPI, Depends
+from sqlmodel import SQLModel, Session, create_engine, select
+from typing import List
+
+from .models import Indicator
+from .ingest import fetch_otx, fetch_shodan, fetch_censys, fetch_virustotal
+from .llm import summarize_iocs
+
+DATABASE_URL = "sqlite:///./ioc.db"
+engine = create_engine(DATABASE_URL, echo=False)
+
+app = FastAPI(title="Sigma Threat Intel API")
+
+
+@app.on_event("startup")
+def on_startup():
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    with Session(engine) as session:
+        yield session
+
+
+@app.post("/ingest", response_model=List[Indicator])
+def ingest_iocs(session: Session = Depends(get_session)):
+    iocs = []
+    iocs.extend(fetch_otx())
+    iocs.extend(fetch_shodan())
+    iocs.extend(fetch_censys())
+    for ip in {ioc.ioc for ioc in iocs if ioc.source != "VirusTotal"}:
+        iocs.extend(fetch_virustotal(ip))
+    for ioc in iocs:
+        session.add(ioc)
+    session.commit()
+    return iocs
+
+
+@app.get("/iocs", response_model=List[Indicator])
+def list_iocs(session: Session = Depends(get_session)):
+    statement = select(Indicator).order_by(Indicator.first_seen.desc()).limit(100)
+    results = session.exec(statement).all()
+    return results
+
+
+@app.get("/summary")
+async def summary(session: Session = Depends(get_session)):
+    statement = select(Indicator.ioc).order_by(Indicator.first_seen.desc()).limit(50)
+    iocs = session.exec(statement).all()
+    text = await summarize_iocs([ioc for ioc in iocs])
+    return {"summary": text}

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,10 @@
+from sqlmodel import SQLModel, Field
+from typing import Optional
+from datetime import datetime
+
+class Indicator(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    source: str
+    ioc: str
+    type: str
+    first_seen: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlmodel
+openai
+requests

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://localhost:8000/:path*'
+      }
+    ];
+  }
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "sigma-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@chakra-ui/react": "^2.8.1",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "swr": "2.3.0"
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,26 @@
+import { ChakraProvider, Box, Heading, Text, List, ListItem } from '@chakra-ui/react';
+import useSWR from 'swr';
+
+const fetcher = (url) => fetch(url).then((res) => res.json());
+
+function HomePage() {
+  const { data: iocs } = useSWR('/api/iocs', fetcher, { refreshInterval: 5000 });
+  const { data: summary } = useSWR('/api/summary', fetcher, { refreshInterval: 10000 });
+
+  return (
+    <ChakraProvider>
+      <Box p={4}>
+        <Heading mb={4}>Live IOC Feed</Heading>
+        <List spacing={2} mb={8}>
+          {iocs && iocs.map((ioc) => (
+            <ListItem key={ioc.id}>{ioc.source}: {ioc.ioc}</ListItem>
+          ))}
+        </List>
+        <Heading size="md" mb={2}>AI Summary</Heading>
+        <Text whiteSpace="pre-wrap">{summary ? summary.summary : 'Loading...'}</Text>
+      </Box>
+    </ChakraProvider>
+  );
+}
+
+export default HomePage;


### PR DESCRIPTION
## Summary
- list IOC ingestion, FastAPI backend, and React frontend in README
- document how to run the Python backend and React frontend
- implement FastAPI backend with SQLModel and LLM summarization
- add multi-source ingestion helpers
- create simple Next.js/Chakra UI frontend

## Testing
- `dotnet test Sigma.sln`

------
https://chatgpt.com/codex/tasks/task_e_688a7e8aa0588324bc538872bc0cda91