### PR TITLE
Update RestSharp version

### DIFF
--- a/src/Sigma.Core/AntSK.Domain.csproj
+++ b/src/Sigma.Core/AntSK.Domain.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SqlSugarCore" Version="5.1.4.145" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
-    <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp" Version="112.1.0" />
     
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.6.2" />
     <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.6.2" />

--- a/src/Sigma.Core/Sigma.Core.csproj
+++ b/src/Sigma.Core/Sigma.Core.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.OpenApi" Version="1.6.2-alpha" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp" Version="112.1.0" />
 	<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.3" />
 	<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.3" />
 	<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />


### PR DESCRIPTION
## Summary
- bump `RestSharp` package to avoid NU1902 vulnerability warning

## Testing
- `dotnet build Sigma.sln -c Release`
- `dotnet test Sigma.sln`


------
https://chatgpt.com/codex/tasks/task_e_688a9f6a80848324949b7eee32664172