### PR TITLE
Fix logging placeholders and restore enum value

### DIFF
--- a/src/Sigma.Core/Domain/Model/Enum/AIModelType.cs
+++ b/src/Sigma.Core/Domain/Model/Enum/AIModelType.cs
@@ -30,6 +30,9 @@ namespace Sigma.Core.Domain.Model.Enum
 
         [Display(Name = "Google Gemini")]
         Gemini = 8,
+
+        [Display(Name = "Mock Output")]
+        Mock = 100,
      }
 
     /// <summary>

--- a/src/Sigma.Core/Utils/OpenAIHttpClientHandler.cs
+++ b/src/Sigma.Core/Utils/OpenAIHttpClientHandler.cs
@@ -11,7 +11,7 @@ namespace Sigma.Core.Utils
             {
                 string requestBody = await request.Content.ReadAsStringAsync();
                 //便于调试查看请求prompt
-                logger.LogInformation("Request Url:@url RequestBody: @requestBody", new { url = request.RequestUri, requestBody });
+                logger.LogInformation("Request Url:{Url} RequestBody: {RequestBody}", request.RequestUri, requestBody);
             }
 
             request.RequestUri = new Uri(new Uri(endPoint), request.RequestUri?.PathAndQuery);
@@ -23,7 +23,7 @@ namespace Sigma.Core.Utils
             {
                 string requestBody = await response.Content.ReadAsStringAsync();
                 //便于调试查看请求prompt
-                logger.LogInformation(requestBody);
+                logger.LogInformation("Response Body: {ResponseBody}", requestBody);
             }
 
             return response;
@@ -38,7 +38,7 @@ namespace Sigma.Core.Utils
             {
                 string requestBody = await request.Content.ReadAsStringAsync();
                 //便于调试查看请求prompt
-                logger.LogInformation("Request Url:@url RequestBody: @requestBody", new { url = request.RequestUri, requestBody });
+                logger.LogInformation("Request Url:{Url} RequestBody: {RequestBody}", request.RequestUri, requestBody);
             }
 
             request.RequestUri = new Uri(new Uri(endPoint), request.RequestUri?.PathAndQuery.Replace("/v1/", "/api/"));
@@ -50,7 +50,7 @@ namespace Sigma.Core.Utils
             {
                 string requestBody = await response.Content.ReadAsStringAsync();
                 //便于调试查看请求prompt
-                logger.LogInformation(requestBody);
+                logger.LogInformation("Response Body: {ResponseBody}", requestBody);
             }
 
             return response;


### PR DESCRIPTION
## Summary
- correct logging placeholders in `OpenAIHttpClientHandler`
- restore `Mock` AI type in `AIModelType` enum

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688b43e9bf148324b7410eeedc12a64a