### PR TITLE
Add STIX TAXII plugin and export helpers

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ requests==2.32.4
 PyPDF2==3.0.1
 beautifulsoup4==4.13.4
 stix2==3.0.1
+taxii2-client==2.3.0

--- a/backend/stix_taxii_client.py
+++ b/backend/stix_taxii_client.py
@@ -1,0 +1,66 @@
+"""Simple TAXII 2.0/2.1 client helpers."""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from taxii2client.v20 import Collection, Server
+from stix2 import Bundle
+
+logger = logging.getLogger(__name__)
+
+
+class StixTaxiiClient:
+    """Helper for interacting with a TAXII server."""
+
+    def __init__(self, server_url: str, username: Optional[str] = None, password: Optional[str] = None):
+        self.server_url = server_url.rstrip("/")
+        self.username = username
+        self.password = password
+        try:
+            self.server = Server(self.server_url, user=username, password=password)
+        except Exception as exc:
+            logger.error("Failed to connect to TAXII server %s: %s", server_url, exc)
+            self.server = None
+
+    def list_collections(self) -> List[dict]:
+        """Return available collections on the TAXII server."""
+        if not self.server:
+            return []
+        cols: List[dict] = []
+        try:
+            for api_root in self.server.api_roots:
+                for col in api_root.collections:
+                    cols.append({"id": col.id, "title": col.title})
+        except Exception as exc:
+            logger.error("Failed to list collections: %s", exc)
+        return cols
+
+    def fetch_objects(self, collection_id: str, since: Optional[str] = None) -> List[dict]:
+        """Fetch STIX objects from a collection."""
+        if not self.server:
+            return []
+        try:
+            api_root = self.server.api_roots[0]
+            url = f"{api_root.url}collections/{collection_id}/"
+            col = Collection(url, user=self.username, password=self.password)
+            resp = col.get_objects(since=since)
+            return resp.get("objects", [])
+        except Exception as exc:
+            logger.error("Failed to fetch objects for collection %s: %s", collection_id, exc)
+            return []
+
+    def push_bundle(self, collection_id: str, bundle: Bundle) -> bool:
+        """Push a STIX bundle into the specified collection."""
+        if not self.server:
+            return False
+        try:
+            api_root = self.server.api_roots[0]
+            url = f"{api_root.url}collections/{collection_id}/"
+            col = Collection(url, user=self.username, password=self.password)
+            col.add_objects(bundle.serialize())
+            return True
+        except Exception as exc:
+            logger.error("Failed to push bundle to collection %s: %s", collection_id, exc)
+            return False
+

--- a/scripts/stix_exporter.py
+++ b/scripts/stix_exporter.py
@@ -1,0 +1,37 @@
+"""Helpers to export IOC data to a STIX bundle."""
+import json
+import sys
+from pathlib import Path
+
+from stix2 import Bundle, DomainName, File, IPv4Address, URL
+
+
+def bundle_from_iocs(iocs: dict) -> Bundle:
+    objects = []
+    for ip in iocs.get("ips", []):
+        objects.append(IPv4Address(value=ip))
+    for domain in iocs.get("domains", []):
+        objects.append(DomainName(value=domain))
+    for url in iocs.get("urls", []):
+        objects.append(URL(value=url))
+    for h in iocs.get("hashes", []):
+        objects.append(File(hashes={"SHA-256": h}))
+    return Bundle(objects)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python stix_exporter.py <iocs.json> <output_bundle.json>")
+        sys.exit(1)
+    in_path = Path(sys.argv[1])
+    out_path = Path(sys.argv[2])
+    with in_path.open() as f:
+        iocs = json.load(f)
+    bundle = bundle_from_iocs(iocs)
+    out_path.write_text(bundle.serialize(indent=2))
+    print(f"Wrote STIX bundle with {len(bundle.objects)} objects to {out_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/Sigma/plugins/StixTaxiiPlugin/CreateBundle/config.json
+++ b/src/Sigma/plugins/StixTaxiiPlugin/CreateBundle/config.json
@@ -1,0 +1,11 @@
+{
+  "schema": 1,
+  "description": "Generate a STIX bundle from IOC data for TAXII export",
+  "execution_settings": {
+    "default": {
+      "temperature": 0.0,
+      "top_p": 0.0
+    }
+  }
+}
+

--- a/src/Sigma/plugins/StixTaxiiPlugin/CreateBundle/skprompt.txt
+++ b/src/Sigma/plugins/StixTaxiiPlugin/CreateBundle/skprompt.txt
@@ -1,0 +1,6 @@
+Create a STIX 2.1 bundle containing the following indicators of compromise.
+Return the bundle as JSON.
+
+Indicators:
+{{$iocs}}
+


### PR DESCRIPTION
## Summary
- add StixTaxiiPlugin to generate STIX bundles from IOC data
- implement TAXII client helper for listing collections, fetching objects and pushing bundles
- add script to build STIX bundles from IOCs and dependency for TAXII client

## Testing
- `pytest -q`
- `python scripts/stix_exporter.py sample_iocs.json output_bundle.json`

------
https://chatgpt.com/codex/tasks/task_e_688e7a9a40708324b43966329817f76c