### PR TITLE
feat: add alert subscriptions

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,15 +1,82 @@
-from fastapi import FastAPI, Depends
-from sqlmodel import SQLModel, Session, create_engine, select
-from typing import List
+"""Main FastAPI application for the Python backend.
 
-from .models import Indicator
-from .ingest import fetch_otx, fetch_shodan, fetch_censys, fetch_virustotal
+This module now also contains a small notification system which can either
+produce messages to Kafka or deliver them to a webhook.  The notifier is very
+light‑weight and is primarily intended to support the demo subscription feature
+implemented in the .NET API and the front‑end.
+
+The behaviour is controlled through the following environment variables:
+
+* ``KAFKA_BROKER`` – address of a Kafka broker.  When provided a producer will
+  be created and each IOC will be written to the topic specified by
+  ``KAFKA_TOPIC`` (default: ``"sigma.alerts"``).
+* ``WEBHOOK_URL`` – if set each IOC will also be sent via HTTP POST to the
+  given URL.  This acts as a simple webhook mechanism for downstream services
+  that do not consume Kafka.
+
+Both mechanisms can be used together.  Failures are logged but do not interrupt
+normal processing of IOC ingestion.
+"""
+
+from typing import List
+import json
+import logging
+import os
+
+import requests
+from fastapi import Depends, FastAPI
+from sqlmodel import SQLModel, Session, create_engine, select
+
+try:  # Kafka is optional; fall back gracefully if the package is missing
+    from kafka import KafkaProducer  # type: ignore
+except Exception:  # pragma: no cover - best effort import
+    KafkaProducer = None
+
+from .ingest import fetch_censys, fetch_otx, fetch_shodan, fetch_virustotal
 from .llm import summarize_iocs
+from .models import Indicator
+
 
 DATABASE_URL = "sqlite:///./ioc.db"
 engine = create_engine(DATABASE_URL, echo=False)
 
 app = FastAPI(title="Sigma Threat Intel API")
+
+
+# ---------------------------------------------------------------------------
+# Notification utilities
+# ---------------------------------------------------------------------------
+KAFKA_BROKER = os.getenv("KAFKA_BROKER")
+KAFKA_TOPIC = os.getenv("KAFKA_TOPIC", "sigma.alerts")
+WEBHOOK_URL = os.getenv("WEBHOOK_URL")
+
+_producer = None
+if KAFKA_BROKER and KafkaProducer is not None:
+    try:
+        _producer = KafkaProducer(
+            bootstrap_servers=KAFKA_BROKER,
+            value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+        )
+    except Exception as exc:  # pragma: no cover - logging is best effort
+        logging.error("Failed to create Kafka producer: %s", exc)
+
+
+def _notify(ioc: Indicator) -> None:
+    """Send IOC information to Kafka and/or webhook subscribers."""
+
+    payload = ioc.model_dump()
+
+    if _producer is not None:
+        try:
+            _producer.send(KAFKA_TOPIC, payload)
+        except Exception as exc:  # pragma: no cover - logging is best effort
+            logging.error("Kafka send failed: %s", exc)
+
+    if WEBHOOK_URL:
+        try:
+            requests.post(WEBHOOK_URL, json=payload, timeout=5)
+        except Exception as exc:  # pragma: no cover - logging is best effort
+            logging.error("Webhook post failed: %s", exc)
 
 
 @app.on_event("startup")
@@ -32,6 +99,7 @@ def ingest_iocs(session: Session = Depends(get_session)):
         iocs.extend(fetch_virustotal(ip))
     for ioc in iocs:
         session.add(ioc)
+        _notify(ioc)
     session.commit()
     return iocs
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn==0.35.0
 sqlmodel==0.0.24
 openai==1.98.0
 requests==2.32.4
+kafka-python==2.0.2
 PyPDF2==3.0.1
 beautifulsoup4==4.13.4
 stix2==3.0.1

--- a/frontend/pages/alerts/index.js
+++ b/frontend/pages/alerts/index.js
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import useSWR from 'swr';
+import {
+  ChakraProvider,
+  Box,
+  Heading,
+  Flex,
+  Input,
+  Button,
+  List,
+  ListItem,
+} from '@chakra-ui/react';
+
+const fetcher = (url) => fetch(url).then((res) => res.json());
+
+export default function AlertsPage() {
+  const { data: subs, mutate } = useSWR('/api/alerts/subscriptions', fetcher);
+  const [endpoint, setEndpoint] = useState('');
+
+  const addSubscription = async () => {
+    if (!endpoint) return;
+    await fetch('/api/alerts/subscriptions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpoint }),
+    });
+    setEndpoint('');
+    mutate();
+  };
+
+  const removeSubscription = async (id) => {
+    await fetch(`/api/alerts/subscriptions/${id}`, { method: 'DELETE' });
+    mutate();
+  };
+
+  return (
+    <ChakraProvider>
+      <Box p={4}>
+        <Heading mb={4}>Alert Subscriptions</Heading>
+        <Flex mb={4}>
+          <Input
+            placeholder="Webhook URL"
+            value={endpoint}
+            onChange={(e) => setEndpoint(e.target.value)}
+          />
+          <Button ml={2} onClick={addSubscription}>
+            Add
+          </Button>
+        </Flex>
+        <List spacing={2}>
+          {subs &&
+            subs.map((s) => (
+              <ListItem key={s.id}>
+                <Flex justify="space-between">
+                  <Box>{s.endpoint}</Box>
+                  <Button
+                    size="xs"
+                    colorScheme="red"
+                    onClick={() => removeSubscription(s.id)}
+                  >
+                    Remove
+                  </Button>
+                </Flex>
+              </ListItem>
+            ))}
+        </List>
+      </Box>
+    </ChakraProvider>
+  );
+}

--- a/src/Sigma/Controllers/AlertsController.cs
+++ b/src/Sigma/Controllers/AlertsController.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Sigma.Controllers
+{
+    /// <summary>
+    /// Simple in-memory management of alert subscriptions. This controller is
+    /// deliberately lightweight and intended for demonstration purposes only.
+    /// </summary>
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AlertsController : ControllerBase
+    {
+        private static readonly List<AlertSubscription> _subscriptions = new();
+
+        /// <summary>
+        /// Get all current subscriptions.
+        /// </summary>
+        [HttpGet("subscriptions")]
+        public IEnumerable<AlertSubscription> GetSubscriptions() => _subscriptions;
+
+        /// <summary>
+        /// Add a new subscription.
+        /// </summary>
+        [HttpPost("subscriptions")]
+        public ActionResult<AlertSubscription> AddSubscription([FromBody] AlertSubscription request)
+        {
+            request.Id = Guid.NewGuid();
+            _subscriptions.Add(request);
+            return Ok(request);
+        }
+
+        /// <summary>
+        /// Remove a subscription by id.
+        /// </summary>
+        [HttpDelete("subscriptions/{id}")]
+        public IActionResult DeleteSubscription(Guid id)
+        {
+            var sub = _subscriptions.FirstOrDefault(s => s.Id == id);
+            if (sub == null)
+            {
+                return NotFound();
+            }
+            _subscriptions.Remove(sub);
+            return NoContent();
+        }
+    }
+
+    /// <summary>
+    /// Model describing a single subscription.
+    /// </summary>
+    public class AlertSubscription
+    {
+        public Guid Id { get; set; }
+        public string? Endpoint { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- notify IOC ingestion through Kafka or webhook
- add alerts subscription API with in-memory store
- create frontend page to manage alert subscriptions

## Testing
- `pytest tests/python/test_ingest.py`
- `dotnet test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e7a9f749c8324959e91c256dd24cc