### PR TITLE
Add Helm charts and deployment documentation

### DIFF
--- a/deploy/helm/backend/Chart.yaml
+++ b/deploy/helm/backend/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: backend
+version: 0.1.0
+description: Helm chart for Sigma backend service
+appVersion: "1.0"

--- a/deploy/helm/backend/templates/deployment.yaml
+++ b/deploy/helm/backend/templates/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: backend
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 8000
+        env:
+        - name: DATABASE_URL
+          value: {{ .Values.env.DATABASE_URL | quote }}
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: OPENAI_API_KEY
+        - name: OTX_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: OTX_API_KEY
+        - name: SHODAN_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: SHODAN_API_KEY
+        - name: CENSYS_UID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: CENSYS_UID
+        - name: CENSYS_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: CENSYS_SECRET
+        - name: VT_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: VT_API_KEY
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-pvc

--- a/deploy/helm/backend/templates/pvc.yaml
+++ b/deploy/helm/backend/templates/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.storage.size }}

--- a/deploy/helm/backend/templates/secret.yaml
+++ b/deploy/helm/backend/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secret
+type: Opaque
+stringData:
+  OPENAI_API_KEY: {{ .Values.secrets.OPENAI_API_KEY | quote }}
+  OTX_API_KEY: {{ .Values.secrets.OTX_API_KEY | quote }}
+  SHODAN_API_KEY: {{ .Values.secrets.SHODAN_API_KEY | quote }}
+  CENSYS_UID: {{ .Values.secrets.CENSYS_UID | quote }}
+  CENSYS_SECRET: {{ .Values.secrets.CENSYS_SECRET | quote }}
+  VT_API_KEY: {{ .Values.secrets.VT_API_KEY | quote }}

--- a/deploy/helm/backend/templates/service.yaml
+++ b/deploy/helm/backend/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: 8000

--- a/deploy/helm/backend/values.yaml
+++ b/deploy/helm/backend/values.yaml
@@ -1,0 +1,22 @@
+image:
+  repository: your-repo/backend
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8000
+
+env:
+  DATABASE_URL: "sqlite:////data/ioc.db"
+
+secrets:
+  OPENAI_API_KEY: ""
+  OTX_API_KEY: ""
+  SHODAN_API_KEY: ""
+  CENSYS_UID: ""
+  CENSYS_SECRET: ""
+  VT_API_KEY: ""
+
+storage:
+  size: 1Gi

--- a/deploy/helm/dotnet/Chart.yaml
+++ b/deploy/helm/dotnet/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: dotnet
+version: 0.1.0
+description: Helm chart for Sigma .NET service
+appVersion: "1.0"

--- a/deploy/helm/dotnet/templates/deployment.yaml
+++ b/deploy/helm/dotnet/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: dotnet
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 80
+        env:
+        - name: EXA_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: EXA_API_KEY
+        - name: ConnectionStrings__DefaultConnection
+          value: {{ .Values.env.ConnectionStrings__DefaultConnection | quote }}
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-pvc

--- a/deploy/helm/dotnet/templates/pvc.yaml
+++ b/deploy/helm/dotnet/templates/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.storage.size }}

--- a/deploy/helm/dotnet/templates/secret.yaml
+++ b/deploy/helm/dotnet/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secret
+type: Opaque
+stringData:
+  EXA_API_KEY: {{ .Values.secrets.EXA_API_KEY | quote }}

--- a/deploy/helm/dotnet/templates/service.yaml
+++ b/deploy/helm/dotnet/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: 80

--- a/deploy/helm/dotnet/values.yaml
+++ b/deploy/helm/dotnet/values.yaml
@@ -1,0 +1,17 @@
+image:
+  repository: your-repo/dotnet
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+env:
+  ConnectionStrings__DefaultConnection: "Data Source=/data/Sigma.db;"
+
+secrets:
+  EXA_API_KEY: ""
+
+storage:
+  size: 1Gi

--- a/deploy/helm/frontend/Chart.yaml
+++ b/deploy/helm/frontend/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: frontend
+version: 0.1.0
+description: Helm chart for Sigma frontend service
+appVersion: "1.0"

--- a/deploy/helm/frontend/templates/deployment.yaml
+++ b/deploy/helm/frontend/templates/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: frontend
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NEXT_PUBLIC_API_URL
+          value: {{ .Values.env.NEXT_PUBLIC_API_URL | quote }}
+        - name: API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secret
+              key: API_KEY
+{{- if .Values.storage.enabled }}
+        volumeMounts:
+        - name: data
+          mountPath: /data
+{{- end }}
+{{- if .Values.storage.enabled }}
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-pvc
+{{- end }}

--- a/deploy/helm/frontend/templates/pvc.yaml
+++ b/deploy/helm/frontend/templates/pvc.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.storage.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.storage.size }}
+{{- end }}

--- a/deploy/helm/frontend/templates/secret.yaml
+++ b/deploy/helm/frontend/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secret
+type: Opaque
+stringData:
+  API_KEY: {{ .Values.secrets.API_KEY | quote }}

--- a/deploy/helm/frontend/templates/service.yaml
+++ b/deploy/helm/frontend/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: 3000

--- a/deploy/helm/frontend/values.yaml
+++ b/deploy/helm/frontend/values.yaml
@@ -1,0 +1,18 @@
+image:
+  repository: your-repo/frontend
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 3000
+
+env:
+  NEXT_PUBLIC_API_URL: "http://backend:8000"
+
+secrets:
+  API_KEY: ""
+
+storage:
+  enabled: false
+  size: 1Gi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,40 @@
+# Deployment
+
+This repository provides Helm charts for deploying the Sigma services to a Kubernetes cluster. Charts are located under `deploy/helm/` for the following components:
+
+- `.NET` service (`deploy/helm/dotnet`)
+- Python backend (`deploy/helm/backend`)
+- Next.js frontend (`deploy/helm/frontend`)
+
+## Prerequisites
+
+- Docker images for each service are available in a registry and referenced in the chart values.
+- A Kubernetes cluster and `helm` installed locally.
+
+## Configuration
+
+Each chart exposes configuration in its `values.yaml` file.
+
+### Secrets
+
+API keys and other sensitive values are defined in the `secrets` section. Update these before deploying. For example, the backend expects keys for providers such as OTX, Shodan, Censys, VirusTotal, and OpenAI.
+
+### Storage
+
+Both the .NET service and backend use SQLite databases and require persistent storage. The `storage` section configures a PersistentVolumeClaim. Adjust the size or disable storage as needed. The frontend chart includes a storage section for completeness but is disabled by default.
+
+## Deploying
+
+Install a chart by specifying a release name and the chart directory. For example, to deploy the backend:
+
+```bash
+helm install sigma-backend deploy/helm/backend \
+  --set image.repository=myrepo/backend \
+  --set secrets.OPENAI_API_KEY=your-openai-key
+```
+
+Repeat for the `.NET` and frontend charts, overriding images and secrets as appropriate. Use `helm upgrade` to apply changes and `helm uninstall` to remove a release.
+
+## Accessing the Services
+
+Each chart exposes a Kubernetes `Service` on the port defined in `values.yaml`. Configure an ingress or port-forward to interact with the applications.


### PR DESCRIPTION
## Summary
- add Helm charts for .NET, backend, and frontend services
- document deploying charts and configuring secrets and storage

## Testing
- `dotnet test`
- `pytest tests/python`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e7aa1e9688324928d7461b4cf5f32