### PR TITLE
Add MITRE mapping service and expose technique mappings

### DIFF
--- a/frontend/pages/report.js
+++ b/frontend/pages/report.js
@@ -1,0 +1,21 @@
+import { ChakraProvider, Box, Heading, List, ListItem } from '@chakra-ui/react';
+import useSWR from 'swr';
+
+const fetcher = (url) => fetch(url).then((res) => res.json());
+
+export default function ReportPage() {
+  const { data } = useSWR('/api/mitre', fetcher, { refreshInterval: 5000 });
+
+  return (
+    <ChakraProvider>
+      <Box p={4}>
+        <Heading mb={4}>MITRE Technique Mappings</Heading>
+        <List spacing={2}>
+          {data && data.map((id, idx) => (
+            <ListItem key={idx}>{id}</ListItem>
+          ))}
+        </List>
+      </Box>
+    </ChakraProvider>
+  );
+}

--- a/src/Sigma.Core/Data/ApplicationDbContext.cs
+++ b/src/Sigma.Core/Data/ApplicationDbContext.cs
@@ -28,6 +28,8 @@ namespace Sigma.Data
 
         public DbSet<ChatHistory> ChatHistories { get; set; }
 
+        public DbSet<Sigma.Core.Repositories.ThreatIntel.MitreMapping> MitreMappings { get; set; }
+
         protected override void OnModelCreating(ModelBuilder builder)
         {
             builder.Entity<Plugin>().HasQueryFilter(x => !x.IsDeleted);
@@ -38,6 +40,7 @@ namespace Sigma.Data
             builder.Entity<Users>().HasQueryFilter(x => !x.IsDeleted);
             builder.Entity<Chat>().HasQueryFilter(x => !x.IsDeleted);
             builder.Entity<ChatHistory>().HasQueryFilter(x => !x.IsDeleted);
+            builder.Entity<Sigma.Core.Repositories.ThreatIntel.MitreMapping>().HasQueryFilter(x => !x.IsDeleted);
 
             base.OnModelCreating(builder);
         }

--- a/src/Sigma.Core/Domain/Service/MitreMappingService.cs
+++ b/src/Sigma.Core/Domain/Service/MitreMappingService.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Sigma.Core.Repositories.ThreatIntel;
+using Sigma.Data;
+
+namespace Sigma.Core.Domain.Service
+{
+    public class MitreMappingService
+    {
+        private static readonly Regex TechniqueRegex = new("T\\d{4}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private readonly ApplicationDbContext _db;
+
+        public MitreMappingService(ApplicationDbContext db)
+        {
+            _db = db;
+        }
+
+        public List<string> MapAndStore(string text)
+        {
+            var ids = TechniqueRegex.Matches(text)
+                .Select(m => m.Value.ToUpperInvariant())
+                .Distinct()
+                .ToList();
+            if (ids.Count == 0)
+            {
+                return ids;
+            }
+            foreach (var id in ids)
+            {
+                _db.Set<MitreMapping>().Add(new MitreMapping { TechniqueId = id });
+            }
+            _db.SaveChanges();
+            return ids;
+        }
+    }
+}

--- a/src/Sigma.Core/Repositories/ThreatIntel/MitreMapping.cs
+++ b/src/Sigma.Core/Repositories/ThreatIntel/MitreMapping.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+using Sigma.Core.Repositories.Base;
+
+namespace Sigma.Core.Repositories.ThreatIntel
+{
+    public class MitreMapping : EntityBase
+    {
+        [Required]
+        public string TechniqueId { get; set; }
+    }
+}

--- a/src/Sigma/Controllers/MitreController.cs
+++ b/src/Sigma/Controllers/MitreController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using Sigma.Data;
+using System.Linq;
+
+namespace Sigma.Controllers
+{
+    [ApiController]
+    [Route("api/mitre")]
+    public class MitreController : ControllerBase
+    {
+        private readonly ApplicationDbContext _db;
+        public MitreController(ApplicationDbContext db)
+        {
+            _db = db;
+        }
+
+        [HttpGet]
+        public IActionResult Get()
+        {
+            var ids = _db.MitreMappings.Select(m => m.TechniqueId).ToList();
+            return Ok(ids);
+        }
+    }
+}

--- a/src/Sigma/Program.cs
+++ b/src/Sigma/Program.cs
@@ -77,6 +77,7 @@ builder.Services.AddScoped<IProfileService, ProfileService>();
 builder.Services.AddScoped<IProjectService, ProjectService>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<ISecurityAssessmentService, SecurityAssessmentService>();
+builder.Services.AddScoped<MitreMappingService>();
 
 builder.Services.AddQueue();
 
@@ -174,5 +175,7 @@ app.MapRazorComponents<Sigma.Client.App>()
 
 // Add additional endpoints required by the Identity /Account Razor components.
 app.MapAdditionalIdentityEndpoints();
+
+app.MapControllers();
 
 app.Run();

--- a/src/Sigma/plugins/Functions/CyberIntelFunctions.cs
+++ b/src/Sigma/plugins/Functions/CyberIntelFunctions.cs
@@ -1,11 +1,18 @@
 using System.Diagnostics;
 using System.Text.Json;
 using Sigma.Core.Common;
+using Sigma.Core.Domain.Service;
 
 namespace Sigma.plugins.Functions;
 
 public class CyberIntelFunctions
 {
+    private readonly MitreMappingService _mitreMappingService;
+
+    public CyberIntelFunctions(MitreMappingService mitreMappingService)
+    {
+        _mitreMappingService = mitreMappingService;
+    }
     /// <summary>
     /// Extract IOCs from a CTI PDF report using the CyberIntel runner.
     /// </summary>
@@ -75,6 +82,8 @@ public class CyberIntelFunctions
         }
 
         var options = new JsonSerializerOptions { WriteIndented = true };
-        return JsonSerializer.Serialize(rules, options);
+        var result = JsonSerializer.Serialize(rules, options);
+        _mitreMappingService.MapAndStore(result);
+        return result;
     }
 }

--- a/src/Sigma/plugins/Functions/CyberRangeFunctions.cs
+++ b/src/Sigma/plugins/Functions/CyberRangeFunctions.cs
@@ -1,10 +1,17 @@
 using System.Diagnostics;
 using Sigma.Core.Common;
+using Sigma.Core.Domain.Service;
 
 namespace Sigma.plugins.Functions;
 
 public class CyberRangeFunctions
 {
+    private readonly MitreMappingService _mitreMappingService;
+
+    public CyberRangeFunctions(MitreMappingService mitreMappingService)
+    {
+        _mitreMappingService = mitreMappingService;
+    }
     /// <summary>
     /// Start the GAN cyber range simulation.
     /// </summary>
@@ -12,7 +19,9 @@ public class CyberRangeFunctions
     [SigmaFunction]
     public string StartSimulation()
     {
-        return RunCommand("start");
+        var output = RunCommand("start");
+        _mitreMappingService.MapAndStore(output);
+        return output;
     }
 
     /// <summary>
@@ -22,7 +31,9 @@ public class CyberRangeFunctions
     [SigmaFunction]
     public string GetMetrics()
     {
-        return RunCommand("metrics");
+        var output = RunCommand("metrics");
+        _mitreMappingService.MapAndStore(output);
+        return output;
     }
 
     /// <summary>
@@ -32,7 +43,9 @@ public class CyberRangeFunctions
     [SigmaFunction]
     public string StopSimulation()
     {
-        return RunCommand("stop");
+        var output = RunCommand("stop");
+        _mitreMappingService.MapAndStore(output);
+        return output;
     }
 
     private static string RunCommand(string command)


### PR DESCRIPTION
## Summary
- add MitreMappingService with regex-based technique extraction and persistence
- wire MitreMappingService into CyberIntel and CyberRange plugins
- expose stored technique IDs via new `/api/mitre` endpoint and show them on report page

## Testing
- `dotnet test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e7a9cb0b483248d34238f5809111b